### PR TITLE
A suggestion of adding View Resume button and renaming Open Resume to…

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,8 @@
               MSCS student at NEU, Oakland • Software Developer • Web Dev
               Enthusiast
             </p>
+            <!-- Suggestion: Consider adding a "View Resume" button to display the PDF on screen.  
+            Also, "Download Resume" might be clearer — "Open Resume" sounds like it will open on-screen. -->
             <a href="./Resume.pdf" class="btn btn-primary">
               Open Resume
             </a>


### PR DESCRIPTION
… Download Resume

I was wondering if it might be helpful to make your PDF viewable on the screen as well as downloadable. You could consider adding a "View Resume" button (that opens it on the page) next to the current "Open Resume" option. Also, renaming it to "Download Resume" might be clearer if the main intention is to download the file — I initially thought "Open Resume" would display it on the screen rather than start a download.